### PR TITLE
Add actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ pickle-email-*.html
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
 
+# Ignore Visual Studio Code files
+/.vscode
+
 # Only include if you have production secrets in this file, which is no longer a Rails default
 # config/secrets.yml
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ The plugin can create its own Angular module and also hook into parts of the cor
 * `frontend/app/module/main.ts`
 
 
-
 This file defines the Angular module for this plugin that gets linked into core `frontend/app/src/modules/plugins/linked`
 
 Any changes made to the frontend require running Angular CLI to update. To do that go to the OpenProject folder (NOT the plugin directory) and execute the following command with the plugin contained in the Gemfile.plugins.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Once you've done that, **in the OpenProject core directory**, run:
 $ bundle install
 $ bundle exec rails db:migrate # creates the models from the plugin
 $ bundle exec rails db:seed # creates default data from the plugin's seeder (`app/seeders`)
-$ bundle exec rails assets:webpack
+$ bundle exec rails assets:angular
 ```
 
 Start the server using:
@@ -265,7 +265,7 @@ The plugin can create its own Angular module and also hook into parts of the cor
 
 * `frontend/app/module/main.ts`
 
-  
+
 
 This file defines the Angular module for this plugin that gets linked into core `frontend/app/src/modules/plugins/linked`
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ In the following sections we will explain some common features that you may want
 
 Each section will list the relevant files you may want to look at and explain the features. Beyond that there are also code comments in the respective files which provide further details.
 
+### Plugin Path in the OpenProject core App
+the files in frontend repository imports other modules in the core app with the `core-app/` prefix which is an alias pointing to `<core-app-root>/frontend/src/app` defined in the `tsconfig.base.json` file, be careful to update import path when configurations change
+
 ### Rails generators
 
 The plugin comes with an executable `bin/rails` which you can use when calling rails generators for generating everything. You will have to define `OPENPROJECT_ROOT` in your environment for it to work unfortunately, because the plugin requires the core to load.

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -15,13 +15,14 @@ import { WorkPackageResource } from "core-app/features/hal/resources/work-packag
     case (kittenAction as WorkPackageAction).key:
       kittenActionHandler(this.getSelectedWorkPackages());
       break;
+
+  icons are located in /vendor/openproject-icon-font/src/icon.svg
+  if no icon is defined, then the key name is used to match an icon.
 */
 
 type WorkPackagesHandler = (workPackages: WorkPackageResource[]) => void;
 
-// TODO handle not logged in
-// icons are located in /vendor/openproject-icon-font/src/icon.svg
-// if no icon is defined, then the key name is used to match an icon.
+// TODO? menu item is shown when not logged in. should be hidden?
 export const kittenAction: WorkPackageAction = {
   text: "Create Kittens",
   key: "createkittens",

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -2,14 +2,19 @@ import { WorkPackageAction } from "core-app/features/work-packages/components/wp
 import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 
 /*  
-  USAGE: import kittenAction into OpenProject core in thw wp-context-menu-directive file
-  in the buildItems function edit the following line to include the plugins actions
+  USAGE: import kittenAction, kittenActionHandler into OpenProject core in the wp-context-menu-directive file
+  
+  Step 1: in the buildItems function edit the following line to include the plugins actions
   
   const items = this.permittedActions.map((action:WorkPackageAction) => ({
-  
   to
-
   const items = this.permittedActions.concat([kittenAction]).map((action:WorkPackageAction) => ({
+
+  Step 2: in the triggerContextMenuAction function add a case for the kitten action
+
+    case (kittenAction as WorkPackageAction).key:
+      kittenActionHandler(this.getSelectedWorkPackages());
+      break;
 */
 
 type WorkPackagesHandler = (workPackages: WorkPackageResource[]) => void;

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -1,22 +1,31 @@
-import {
-  WorkPackageAction,
-} from 'core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+import { WorkPackageAction } from "core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service";
+import { WorkPackageResource } from "core-app/features/hal/resources/work-package-resource";
 
-const action:WorkPackageAction = {
-    text: 'Create Kittens',
-    key: 'newactionkey',
-    link: '/angular_kittens',
-}
+/*  
+  USAGE: import kittenAction into OpenProject core in thw wp-context-menu-directive file
+  in the buildItems function edit the following line to include the plugins actions
+  
+  const items = this.permittedActions.map((action:WorkPackageAction) => ({
+  
+  to
 
-export const menuItem = {
-  class: undefined as string|undefined,
-  disabled: false,
-  linkText: action.text,
-  href: action.href,
-  icon: action.icon != null ? action.icon : `icon-${action.key}`,
-  onClick: (_:JQuery.TriggeredEvent) => {
-    // do something
-    window.location.href=action.link!
-    return true;
-  },
-}
+  const items = this.permittedActions.concat([kittenAction]).map((action:WorkPackageAction) => ({
+*/
+
+type WorkPackagesHandler = (workPackages: WorkPackageResource[]) => void;
+
+// TODO handle not logged in
+// icons are located in /vendor/openproject-icon-font/src/icon.svg
+// if no icon is defined, then the key name is used to match an icon.
+export const kittenAction: WorkPackageAction = {
+  text: "Create Kittens",
+  key: "createkittens",
+  link: "/angular_kittens",
+  href: undefined,
+  icon: 'icon-info1',
+  indexBy: undefined,
+};
+
+export const kittenActionHandler: WorkPackagesHandler = (workPackages: WorkPackageResource[]) => {
+  window.location.href = kittenAction.link + '?ids=' + workPackages.map(wp => wp.id).join(',');
+};

--- a/frontend/module/context-menu.ts
+++ b/frontend/module/context-menu.ts
@@ -1,0 +1,22 @@
+import {
+  WorkPackageAction,
+} from 'core-app/features/work-packages/components/wp-table/context-menu-helper/wp-context-menu-helper.service';
+
+const action:WorkPackageAction = {
+    text: 'Create Kittens',
+    key: 'newactionkey',
+    link: '/angular_kittens',
+}
+
+export const menuItem = {
+  class: undefined as string|undefined,
+  disabled: false,
+  linkText: action.text,
+  href: action.href,
+  icon: action.icon != null ? action.icon : `icon-${action.key}`,
+  onClick: (_:JQuery.TriggeredEvent) => {
+    // do something
+    window.location.href=action.link!
+    return true;
+  },
+}

--- a/frontend/module/kitten-page/kitten-page.component.ts
+++ b/frontend/module/kitten-page/kitten-page.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit} from '@angular/core';
-import {I18nService} from 'core-app/modules/common/i18n/i18n.service';
+import {I18nService} from 'core-app/core/i18n/i18n.service';
 
 @Component({
     templateUrl: './kitten-page.component.html',

--- a/frontend/module/kitten.routes.ts
+++ b/frontend/module/kitten.routes.ts
@@ -1,5 +1,5 @@
 import {Ng2StateDeclaration} from '@uirouter/angular';
-import {KittenPageComponent} from 'core-app/modules/plugins/linked/openproject-proto_plugin/kitten-page/kitten-page.component';
+import {KittenPageComponent} from 'core-app/features/plugins/linked/openproject-proto_plugin/kitten-page/kitten-page.component';
 
 export const KITTEN_ROUTES:Ng2StateDeclaration[] = [
     {

--- a/frontend/module/main.ts
+++ b/frontend/module/main.ts
@@ -37,13 +37,13 @@
 
 import {APP_INITIALIZER, Injector, NgModule} from '@angular/core';
 import {CommonModule} from "@angular/common";
-import {KittenComponent} from "core-app/modules/plugins/linked/openproject-proto_plugin/kitten-component/kitten.component";
-import {HookService} from "core-app/modules/plugins/hook-service";
+import {KittenComponent} from "core-app/features/plugins/linked/openproject-proto_plugin/kitten-component/kitten.component";
+import {HookService} from "core-app/features/plugins/hook-service";
 
 import './global_scripts'
-import {KITTEN_ROUTES} from 'core-app/modules/plugins/linked/openproject-proto_plugin/kitten.routes';
+import {KITTEN_ROUTES} from 'core-app/features/plugins/linked/openproject-proto_plugin/kitten.routes';
 import {UIRouterModule} from '@uirouter/angular';
-import {KittenPageComponent} from 'core-app/modules/plugins/linked/openproject-proto_plugin/kitten-page/kitten-page.component';
+import {KittenPageComponent} from 'core-app/features/plugins/linked/openproject-proto_plugin/kitten-page/kitten-page.component';
 
 export function initializeProtoPlugin(injector:Injector) {
   return () => {
@@ -78,6 +78,3 @@ export function initializeProtoPlugin(injector:Injector) {
 })
 export class PluginModule {
 }
-
-
-


### PR DESCRIPTION
This PR adds the menuItem to the protoplugin. 

To use this, in open project core

import menuItem in the `wp-view-context-menu.directive.ts`

and then in the buildItems` function, before items is returned. add `items.push(menuItem)`.