### PR TITLE
Changes to make the plugin compatible with 13.1

### DIFF
--- a/app/views/homescreen/blocks/_homescreen_block.html.erb
+++ b/app/views/homescreen/blocks/_homescreen_block.html.erb
@@ -14,7 +14,7 @@
 </ul>
 
 <div class="widget-box--blocks--buttons">
-  <% if User.current.allowed_to?(:manage_kittens, nil, global: true) %>
+  <% if User.current.allowed_in_any_project?(:manage_kittens) %>
     <%= link_to new_kitten_plugin_project_kitten_path(project_id: Project.first.identifier), {
       class: 'button -alt-highlight',
       aria: {label: t(:label_kitten_new)},

--- a/app/views/kittens/index.html.erb
+++ b/app/views/kittens/index.html.erb
@@ -2,7 +2,7 @@
 
 
 <%= toolbar(title: t(:label_kittens)) do %>
-  <% if current_user.allowed_to?(:manage_kittens, @project, global: @project.nil?) %>
+  <% if (@project.present? && current_user.allowed_in_project?(:manage_kittens, @project)) || (@project.nil? && current_user.allowed_in_any_project?(:manage_kittens)) %>
     <li class="toolbar-item">
       <%= link_to(new_kitten_plugin_project_kitten_path, class: 'button') do %>
         <span class="button--text"><%= t(:label_kitten_new) %></span>

--- a/lib/open_project/proto_plugin/engine.rb
+++ b/lib/open_project/proto_plugin/engine.rb
@@ -12,7 +12,7 @@ module OpenProject::ProtoPlugin
     register(
       'openproject-proto_plugin',
       :author_url => 'https://openproject.org',
-      :requires_openproject => '>= 6.0.0'
+      :requires_openproject => '>= 13.1.0'
     ) do
       # We define a new project module here for our controller including a permission.
       # The permission is necessary for us to be able to add menu items to the project
@@ -23,12 +23,18 @@ module OpenProject::ProtoPlugin
       # settings before you can see the menu entry.
       project_module :kittens_module do
         permission :view_kittens,
-                   kittens: %i[index],
-                   angular_kittens: %i[show]
+                   {
+                      kittens: %i[index],
+                      angular_kittens: %i[show]
+                   },
+                   permissible_on: [:project]
 
         permission :manage_kittens,
-                   kittens: %i[new create edit destroy],
-                   angular_kittens: %i[show]
+                   {
+                      kittens: %i[new create edit destroy],
+                      angular_kittens: %i[show]
+                   },
+                   permissible_on: [:project]
       end
 
       menu :project_menu,

--- a/spec/controllers/kittens_controller_spec.rb
+++ b/spec/controllers/kittens_controller_spec.rb
@@ -30,7 +30,7 @@
 
 require 'spec_helper'
 
-describe KittensController, type: :controller do
+RSpec.describe KittensController, type: :controller do
   let(:user) { FactoryBot.create :admin }
   let(:project) { FactoryBot.create :project }
 

--- a/spec/features/project_kittens_spec.rb
+++ b/spec/features/project_kittens_spec.rb
@@ -34,7 +34,7 @@ require 'spec_helper'
 # js:true will enable a JS-compatible browser (Chrome by default)
 #
 # Testing is done with Capybara and Selenium
-describe 'Project kittens', type: :feature, js: true do
+RSpec.describe 'Project kittens', type: :feature, js: true do
   let(:permissions) { %w[view_kittens manage_kittens] }
   let(:project) { FactoryBot.create :project, enabled_module_names: %w[kittens_module] }
   let(:user) do

--- a/spec/features/project_kittens_spec.rb
+++ b/spec/features/project_kittens_spec.rb
@@ -39,8 +39,7 @@ describe 'Project kittens', type: :feature, js: true do
   let(:project) { FactoryBot.create :project, enabled_module_names: %w[kittens_module] }
   let(:user) do
     FactoryBot.create :user,
-                      member_in_project: project,
-                      member_with_permissions: permissions
+                      member_with_permissions: { project => permissions }
   end
 
   before do


### PR DESCRIPTION
- Permissions need a new definition of what entity they are allowed on
- Permission checks should use the new methods
- We disabled the [zero monkey patching mode](https://github.com/opf/openproject/pull/12738) for RSpec, thus the test needs to be initialized with `RSpec.describe`

---

Implements https://community.openproject.org/projects/openproject/work_packages/50714