### PR TITLE
fix(proto-plugin): align Kittens UI with current OpenProject

### DIFF
--- a/app/views/hooks/proto_plugin/_view_layouts_base_sidebar.html.erb
+++ b/app/views/hooks/proto_plugin/_view_layouts_base_sidebar.html.erb
@@ -1,3 +1,1 @@
-<p style="color: red;">
-  :view_layouts_base_sidebar hook
-</p>
+<%# Optional sidebar content for proto_plugin; hook is wired in OpenProject::ProtoPlugin::Hooks. %>

--- a/app/views/kittens/index.html.erb
+++ b/app/views/kittens/index.html.erb
@@ -1,14 +1,34 @@
 <% html_title t(:label_kittens) %>
 
+<% breadcrumb_items =
+     if @project
+       [{ href: project_overview_path(@project), text: @project.name }, t(:label_kittens)]
+     else
+       [t(:label_kittens)]
+     end
+%>
 
-<%= toolbar(title: t(:label_kittens)) do %>
-  <% if (@project.present? && current_user.allowed_in_project?(:manage_kittens, @project)) || (@project.nil? && current_user.allowed_in_any_project?(:manage_kittens)) %>
-    <li class="toolbar-item">
-      <%= link_to(new_kitten_plugin_project_kitten_path, class: 'button') do %>
-        <span class="button--text"><%= t(:label_kitten_new) %></span>
-      <% end %>
-    </li>
-  <% end %>
+<%=
+  render(Primer::OpenProject::PageHeader.new) do |header|
+    header.with_title { t(:label_kittens) }
+    header.with_breadcrumbs(breadcrumb_items)
+  end
+%>
+
+<% if @project.present? && current_user.allowed_in_project?(:manage_kittens, @project) %>
+  <%=
+    render(Primer::OpenProject::SubHeader.new) do |subheader|
+      subheader.with_action_button(
+        scheme: :primary,
+        leading_icon: :plus,
+        label: t(:label_kitten_new),
+        tag: :a,
+        href: new_kitten_plugin_project_kitten_path(project_id: @project)
+      ) do
+        t(:label_kitten_new)
+      end
+    end
+  %>
 <% end %>
 
 


### PR DESCRIPTION
This pull request updates the UI for the kittens index page and cleans up a plugin hook template. The main focus is on improving the kittens page header and action button using the new Primer components, and removing unused or placeholder content.

UI improvements on kittens index page:

* Replaced the legacy `toolbar` with the new `Primer::OpenProject::PageHeader` and `SubHeader` components in `app/views/kittens/index.html.erb`. This modernizes the page header, adds breadcrumbs, and updates the "New Kitten" button to use the new design system.
* Improved breadcrumb logic to show the project name when viewing kittens within a project.

Code cleanup:

* Removed placeholder sidebar content from `app/views/hooks/proto_plugin/_view_layouts_base_sidebar.html.erb` and replaced it with a comment explaining the hook.